### PR TITLE
 feat: Add optional email parameter to embedded url

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -25,6 +25,15 @@
         "doc",
         "code"
       ]
+    },
+    {
+      "login": "wvdlTillable",
+      "name": "Bill Van Der Laan",
+      "avatar_url": "https://avatars.githubusercontent.com/u/109123517?v=4",
+      "profile": "https://github.com/wvdlTillable",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ poetry install
 
 Run tests.
 ```bash
+cd tests
 poetry run pytest
 ```
 
@@ -86,6 +87,7 @@ Other conventional commits such as `chore`, `ci`, `test`, `refactor`, etc will n
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/dtiesling"><img src="https://avatars.githubusercontent.com/u/7133255?v=4?s=100" width="100px;" alt="Danny Tiesling"/><br /><sub><b>Danny Tiesling</b></sub></a><br /><a href="https://github.com/camoag/omni-sdk/commits?author=dtiesling" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/spra85"><img src="https://avatars.githubusercontent.com/u/423943?v=4?s=100" width="100px;" alt="Chris Sprehe"/><br /><sub><b>Chris Sprehe</b></sub></a><br /><a href="https://github.com/camoag/omni-sdk/commits?author=spra85" title="Documentation">📖</a> <a href="https://github.com/camoag/omni-sdk/commits?author=spra85" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/wvdlTillable"><img src="https://avatars.githubusercontent.com/u/109123517?v=4" width="100px;" alt="Chris Sprehe"/><br /><sub><b>Bill Van Der Laan</b></sub></a><br /><a href="https://github.com/camoag/omni-sdk/commits?author=wvdlTillable" title="Documentation">📖</a> <a href="https://github.com/camoag/omni-sdk/commits?author=wvdlTillable" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/src/omni/embed.py
+++ b/src/omni/embed.py
@@ -21,6 +21,7 @@ class DashboardEmbedUrl:
     name: str
     nonce: str
     customTheme: str | None = None
+    email: str | None = None
     entity: str | None = None
     filterSearchParam: str | None = None
     linkAccess: str | None = None
@@ -116,6 +117,7 @@ class OmniDashboardEmbedder:
         external_id: str,
         name: str,
         custom_theme: dict | None = None,
+        email: str | None = None,
         entity: str | None = None,
         filter_search_params: str | dict | None = None,
         link_access: bool | list[str] | None = None,
@@ -131,6 +133,7 @@ class OmniDashboardEmbedder:
             external_id: Required parameter creating a unique ID. This can be any alphanumeric value.
             name: Required parameter and can contain a non-unique name for the embed user's name property.
             custom_theme: Allows you to stylize your embedded dashboard to your preferred colors.
+            email: Optional parameter with the user's email.
             entity: An id to reference the entity the user belongs to. Commonly is the customer name or other
                 identifying organization for this user.
             filter_search_params: Encoded string or a dict representing dashboard filter values . This can be derived
@@ -176,6 +179,7 @@ class OmniDashboardEmbedder:
             externalId=external_id,
             name=name,
             customTheme=compact_json_dump(custom_theme) if custom_theme else None,
+            email=email,
             entity=entity,
             filterSearchParam=filter_search_params,
             linkAccess=_link_access,
@@ -193,7 +197,7 @@ class OmniDashboardEmbedder:
         """Creates a signature and adds it to the URL object."""
 
         # IMPORTANT: These must be in the correct order as documented here
-        # https://docs.omni.co/docs/embed/private-embedding#manually-generate-a-signature-and-url-hard-mode
+        # https://docs.omni.co/docs/embed/external-embedding/setting-up-the-infrastructure#manually-generate-a-signature-and-url-hard-mode
         blob_items = [
             url.base_url,
             url.contentPath,
@@ -201,6 +205,7 @@ class OmniDashboardEmbedder:
             url.name,
             url.nonce,
             url.customTheme,
+            url.email,
             url.entity,
             url.filterSearchParam,
             url.linkAccess,

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -53,6 +53,7 @@ class TestUnit:
                 "dashboard-background": "#00FF00",
                 "dashboard-tile-background": "#00FF00",
             },
+            email="somebody@example.com",
             entity="Acme",
             filter_search_params={"state": "GA"},
             link_access=True,
@@ -67,13 +68,14 @@ class TestUnit:
             "&name=Somebody"
             "&nonce=365f7003aa5b4f3586d9b81b4a5d9f69"
             "&customTheme=%7B%22dashboard-background%22%3A%22%2300FF00%22%2C%22dashboard-tile-background%22%3A%22%2300FF00%22%7D"
+            "&email=somebody%40example.com"
             "&entity=Acme"
             "&filterSearchParam=state%3DGA"
             "&linkAccess=__omni_link_access_open"
             "&prefersDark=true"
             "&theme=dawn"
             "&userAttributes=%7B%22country%22%3A%22USA%22%7D"
-            "&signature=Y8Alg2Sfdi5WdbwzU4QEugs3HdwLfEvXuBv8UU3BBZw%3D"
+            "&signature=hgchoLoFN3y3cXe4gJXSrInXdAqMcdcOyT6xVRaU2WU%3D"
         )
 
         url = vanity_domain_embedder.build_url(


### PR DESCRIPTION
This change adds an email parameter to the embedded url. This keeps the sdk in line with the most recent omni update which allows the email as a parameter.

I also updated the docs and a broken link in one of the comments.

I added myself as a contributor